### PR TITLE
Fixed names of files to match with file name

### DIFF
--- a/webroot/css/weatherscan.css
+++ b/webroot/css/weatherscan.css
@@ -58,13 +58,13 @@
 }
 @font-face {
   font-family: Frutiger;
-  src: url(/fonts/newfonts/Frutiger.woff) format("woff");
+  src: url(/fonts/newfonts/frutiger.woff) format("woff");
   font-weight: 400;
   font-style: normal
 }
 @font-face {
   font-family: Frutiger;
-  src: url(/fonts/newfonts/Frutiger_Bold.woff) format("woff");
+  src: url(/fonts/newfonts/Frutiger_bold.woff) format("woff");
   font-weight: bold;
   font-style: normal
 }


### PR DESCRIPTION
Fix an issue of "Frutiger_bold.woff" and "frutiger.woff" being named incorrectly