### PR TITLE
Temporary fix for Mapbox dragging

### DIFF
--- a/webroot/index.html
+++ b/webroot/index.html
@@ -2084,7 +2084,7 @@
     <div class="gradient3"></div>
   </div>
   <div id="minimap-title"><span>PAST 3 HOURS</span></div>
-  <div id="minimap">
+  <div id="minimap" style="pointer-events: none">
     <div id="minimap-1" class="map"></div>
     <div id="minimap-2" class="map"></div>
     <div id="minimap-3" class="map"></div>


### PR DESCRIPTION
Temporary fix for interacting with the radar, disabling you from touching, panning, and zooming in/out the radar.