### PR TITLE
Fix a typo

### DIFF
--- a/webroot/index.html
+++ b/webroot/index.html
@@ -1549,7 +1549,7 @@
             Never try to out-drive a tornado
             <br><br>
             Tornadoes can change direction quickly and<br>
-            can lift a car ot truck and toss it through<br>
+            can lift a car or truck and toss it through<br>
             the air.
           </div>
           <div class='drivingtip' style="display: none"><!--originally shown in September 2010, October 2017--->


### PR DESCRIPTION
'or' is misspelled as 'ot' in the tornado safety tip.